### PR TITLE
Update to the latest wit-bindgen.

### DIFF
--- a/wit-abi/Cargo.lock
+++ b/wit-abi/Cargo.lock
@@ -181,9 +181,9 @@ checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dee68f85cab8cf68dec42158baf3a79a1cdc065a8b103025965d6ccb7f6cbd"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
 dependencies = [
  "tinyvec",
 ]
@@ -225,7 +225,7 @@ dependencies = [
 [[package]]
 name = "wit-parser"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#32cd6dafab634b9233bfd394579b64a38ac30b04"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#206263e357ac70acd26a17b1f9ec06758b6418cd"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/wit-abi/src/main.rs
+++ b/wit-abi/src/main.rs
@@ -118,6 +118,7 @@ impl Markdown {
                     self.type_expected(iface, id, name, expected, &ty.docs)
                 }
                 TypeDefKind::Union(union) => self.type_union(iface, id, name, union, &ty.docs),
+                TypeDefKind::Future(t) => self.type_future(iface, id, name, t, &ty.docs),
                 TypeDefKind::Stream(stream) => self.type_stream(iface, id, name, stream, &ty.docs),
             }
         }
@@ -352,6 +353,23 @@ impl Markdown {
         self.src.push_str("\n\n");
     }
 
+    fn type_future(
+        &mut self,
+        iface: &Interface,
+        id: TypeId,
+        name: &str,
+        type_: &Type,
+        docs: &Docs,
+    ) {
+        self.print_type_header(name);
+        self.src.push_str("future\n\n");
+        self.print_type_info(id, docs);
+        self.src.push_str("\n### Future\n\n");
+        self.src.push_str(&format!("- ",));
+        self.print_ty(iface, &type_, false);
+        self.src.push_str("\n\n");
+    }
+
     fn type_stream(
         &mut self,
         iface: &Interface,
@@ -361,7 +379,7 @@ impl Markdown {
         docs: &Docs,
     ) {
         self.print_type_header(name);
-        self.src.push_str("expected\n\n");
+        self.src.push_str("stream\n\n");
         self.print_type_info(id, docs);
         self.src.push_str("\n### Stream\n\n");
         self.src.push_str(&format!("- ok: ",));
@@ -486,6 +504,11 @@ impl Markdown {
                             }
                             self.print_ty(iface, &f.ty, false);
                         }
+                        self.src.push_str(">");
+                    }
+                    TypeDefKind::Future(t) => {
+                        self.src.push_str("future<");
+                        self.print_ty(iface, t, false);
                         self.src.push_str(">");
                     }
                     TypeDefKind::Stream(Stream { element, end }) => {


### PR DESCRIPTION
This add support for parsing the `future` type.