### PR TITLE
Update to the latest wit-bindgen.

### DIFF
--- a/wit-abi/Cargo.lock
+++ b/wit-abi/Cargo.lock
@@ -224,8 +224,8 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#206263e357ac70acd26a17b1f9ec06758b6418cd"
+version = "0.2.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#2c3b7fede8eb5448801328bd6c523f130a06b2a7"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/wit-abi/src/main.rs
+++ b/wit-abi/src/main.rs
@@ -153,7 +153,7 @@ impl Markdown {
                 }
             }
             if func.results.len() > 0 {
-                self.src.push_str("##### Result\n\n");
+                self.src.push_str("##### Results\n\n");
                 match &func.results {
                     Results::Named(results) => {
                         for (name, ty) in results.iter() {


### PR DESCRIPTION
This renames expected to result, removes unit, and handles multiple return values.