### PR TITLE
Link to wit-bindgen, prepare for archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Wasi Tools
 
-... TODO put more here ...
+This repository previously contained a tool named wit-abi, which among other things generated markdown descriptions of Wit APIs.
+
+This functionality is now part of [wit-bindgen], and wit-abi is no longer used.
+
+[wit-bindgen]: https://github.com/bytecodealliance/wit-bindgen


### PR DESCRIPTION
This repository only ever contained the wit-abi tool, and it's now replaced by wit-bindgen in practice, so edit the README to add a link to wit-bindgen.

Once this is merged, I propose to archive this repository.
